### PR TITLE
Fix travis-ci test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
     - "2.6"
     - "2.7"
 install:
-    - python setup.py develop
-    - cd demo; python setup.py develop; cd ..
+    - pip install -e ./
+    - "cd demo; pip install -e ./; cd .."
 script: demo test

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,12 @@ NAME = 'django-generic-filters'
 README = read_relative_file('README.rst')
 VERSION = read_relative_file('VERSION')
 PACKAGES = ['django_genericfilters']
-REQUIRES = ['setuptools', 'Django', 'bunch', 'django-templateaddons']
+REQUIRES = [
+    'setuptools',
+    'Django',
+    'bunch',
+    'django-templateaddons',
+]
 
 
 if __name__ == '__main__':  # Don't run setup() when we import this module.


### PR DESCRIPTION
Looks like travis-ci is unable to correctly pick Django out of the requirements.

see:

https://travis-ci.org/novapost/django-generic-filters/jobs/30049043 (job 86.1 and 86.2)

```
Installed /home/travis/virtualenv/python2.7.6/lib/python2.7/site-packages/bunch-1.0.1-py2.7.egg
Searching for Django
Best match: django templateaddons-0.1
Downloading https://pypi.python.org/packages/source/d/django-templateaddons/django-templateaddons-0.1.tar.gz#md5=88132cd45faf5c0275222810cb3fa1c7
Processing django-templateaddons-0.1.tar.gz
Writing /tmp/easy_install-_mOfUo/django-templateaddons-0.1/setup.cfg
Running django-templateaddons-0.1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-_mOfUo/django-templateaddons-0.1/egg-dist-tmp-g8C2xJ
warning: no files found matching 'distribute_setup.cfg'
zip_safe flag not set; analyzing archive contents...
django-templateaddons 0.1 is already the active version in easy-install.pth
Installed /home/travis/virtualenv/python2.7.6/lib/python2.7/site-packages/django_templateaddons-0.1-py2.7.egg
error: Could not find required distribution Django
```
