### PR TITLE
Add links to alternative

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,3 +116,9 @@ Ressources
 * Code repository: https://github.com/novapost/django-generic-filters
 * Bugtracker: https://github.com/novapost/django-generic-filters/issues
 * Continuous integration: https://travis-ci.org/novapost/django-generic-filters
+
+**********
+Alternatives
+**********
+If the project does not meet your requirements - change it by pull requests or use an alternate `django-filter
+<https://github.com/alex/django-filter>`_.


### PR DESCRIPTION
Hello,

I am would like suggest to add information about alex/django-filter to README.rst, so users who can't use django-generic-filters will use django-filter.

I will pull requests note to django-filter.

 Greetings,
