### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ See "mixin" documentation for details.
 Ressources
 **********
 
-* Documentation: http://django-generic-filters.readthedocs.org
+* Documentation: https://django-generic-filters.readthedocs.io
 * PyPI page: http://pypi.python.org/pypi/django-generic-filters
 * Code repository: https://github.com/novapost/django-generic-filters
 * Bugtracker: https://github.com/novapost/django-generic-filters/issues

--- a/docs/dev.txt
+++ b/docs/dev.txt
@@ -116,4 +116,4 @@ References
 .. _`Python`: http://python.org
 .. _`Virtualenv`: http://virtualenv.org
 .. _`style guide for Sphinx-based documentations`:
-   http://documentation-style-guide-sphinx.readthedocs.org/
+   https://documentation-style-guide-sphinx.readthedocs.io/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.