### PR TITLE
Remove setuptools from install_require in setup.py

### DIFF
--- a/demo/demoproject/settings.py
+++ b/demo/demoproject/settings.py
@@ -48,7 +48,6 @@ INSTALLED_APPS = (
     'demoproject.filter',
     # For test purposes. The demo project is part of
     # django-generic-filters test suite.
-    'django_nose',
     'templateaddons'
 )
 
@@ -75,17 +74,3 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 # Development configuration.
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-NOSE_ARGS = ['--verbose',
-             '--nocapture',
-             '--rednose',
-             '--with-id',  # allows --failed which only reruns failed tests
-             '--id-file=%s' % join(data_dir, 'noseids'),
-             '--with-doctest',
-             '--with-xunit',
-             '--xunit-file=%s' % join(data_dir, 'nosetests.xml'),
-             '--with-coverage',
-             '--cover-erase',
-             '--cover-package=django_genericfilters',
-             '--no-path-adjustment',
-             '--all-modules']

--- a/demo/demoproject/wsgi.py
+++ b/demo/demoproject/wsgi.py
@@ -13,13 +13,13 @@ framework.
 
 """
 import os
+from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "%s.settings" % __package__)
 
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
-from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
 
 # Apply WSGI middleware here.

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -15,7 +15,7 @@ README = read_relative_file('README')
 VERSION = '0.1'
 PACKAGES = ['demoproject']
 REQUIRES = ['django-generic-filters', 'mock', 'Django<1.7'
-            'django-nose', 'coverage', 'rednose']
+            'coverage', ]
 
 
 setup(name=NAME,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ README = read_relative_file('README.rst')
 VERSION = read_relative_file('VERSION')
 PACKAGES = ['django_genericfilters']
 REQUIRES = [
-    'setuptools',
     'Django',
     'bunch',
     'django-templateaddons',
@@ -41,4 +40,5 @@ if __name__ == '__main__':  # Don't run setup() when we import this module.
           packages=PACKAGES,
           include_package_data=True,
           install_requires=REQUIRES,
+          setup_requires=['setuptools'],
           )

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ commands =
     pip install -e ./
     pip install -e demo
     demo test
-deps = django-nose
 
 [testenv:flake8]
 commands =


### PR DESCRIPTION
setuptools is considered unsafe to be set in install_require as all the
setup requirements for a project (python packaging pip related for
instance).

This PR remove it from the install_require. This also avoids some
conflicts or warning from other projects.