### PR TITLE
Fixing Django 4.0 definition in tox.ini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
 
+    # When testing new Python or Django versions, one should use the
+    # filterwarnings definition of setup.cfg to turn deprecation warnings
+    # into errors.
     strategy:
       matrix:
         include:

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,10 @@ testpaths =
     django_genericfilters/tests
     demoproject/tests.py
 filterwarnings =
-    error
+    # Uncomment below when testing a new version of Python or Django so that
+    # DeprecationWarnings can be treated as errors
+    # error
+    ignore:.*distutils Version classes are deprecated.*:DeprecationWarning
 
 DJANGO_SETTINGS_MODULE = demoproject.settings
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     django30: psycopg2<2.9  # https://github.com/django/django/commit/837ffcfa681d0f65f444d881ee3d69aec23770be
     django31: Django==3.1.*
     django32: Django==3.2.*
-    django40: Django==3.2.*
+    django40: Django==4.0.*
 commands =
     pytest {posargs}
 passenv =


### PR DESCRIPTION
Also, ignoring a distutils warning that makes the test fail when we turn warnings in errors in setup.cfg.
