### PR TITLE
Publish workflow should just run on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - '*'
-  release:
-    types:
-      - published
 
 jobs:
   deploy:


### PR DESCRIPTION
Fixes the publish workflow which runs twice, one of which will fail.

Closes #<ticket number>

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
- [ ] Tests
  - [x] (not applicable?)
